### PR TITLE
SINGLE is now default configuration for rooms

### DIFF
--- a/app/public/controllers/reservations/edit.js
+++ b/app/public/controllers/reservations/edit.js
@@ -85,6 +85,7 @@ app.controller( "ReservationEditCtrl",
 
             var contained = getById( $scope.selectedRooms, room.id );
             if( !contained ) {
+                room.configuration = "SINGLE";
                 $scope.selectedRooms.push( room );
 
                 //select the item in the listbox right away to avoid empty item


### PR DESCRIPTION
Prevents accidentally adding a room without a configuration to a reservation.